### PR TITLE
fix(createRichTextObjectResolver): text node value

### DIFF
--- a/lib/parser/implementation/shared.ts
+++ b/lib/parser/implementation/shared.ts
@@ -8,7 +8,7 @@ import {
     IParserElementAttribute
 } from '@kontent-ai/delivery-sdk';
 import { parseFragment, serialize } from 'parse5';
-import { Element, DocumentFragment, ChildNode, ParentNode } from 'parse5/dist/cjs/tree-adapters/default';
+import { Element, DocumentFragment, ChildNode, ParentNode, TextNode } from 'parse5/dist/cjs/tree-adapters/default';
 import * as striptags from 'striptags';
 
 export function getChildNodes(documentFragment: DocumentFragment): ChildNode[] {
@@ -157,7 +157,7 @@ export function convertToParserElement(node: ParentNode): IParserElement {
             }
         },
         html: serialize(node),
-        text: striptags(serialize(node)),
+        text: tagName === '#text' ? (node as unknown as TextNode).value : striptags(serialize(node)),
         attributes: attributes,
         parentElement: (node as Element).parentNode
             ? convertToParserElement((node as Element).parentNode as ParentNode)

--- a/test/node/sync/node-rich-text-object-resolver.spec.js
+++ b/test/node/sync/node-rich-text-object-resolver.spec.js
@@ -24,4 +24,11 @@ describe('Node rich text object resolver', () => {
   it(`Expect correct number of root children nodes`, () => {
     assert.ok(resolvedData.data.children.length === expectedRootChildrenNodes);
   });
+
+  it(`Expect text nodes should be extracted`, () => {
+    const textChildren = Object.values(resolvedData.data.children).filter(({ tag }) => tag === '#text');
+    const filledTextChildren = textChildren.filter(({ data: { text } }) => !!text);
+
+    assert.ok(textChildren.length === filledTextChildren.length);
+  });
 });


### PR DESCRIPTION
### Motivation

Which issue does this fix? Fixes #4

A text node serialized with parse5 has no child so no value is returned. With these changes, we check the type and avoid the serialization.

### Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

If manual testing is required, what are the steps?
